### PR TITLE
Add support for "NOT" operator in "Where" expressions/clause

### DIFF
--- a/Example/Assets/Scripts/SQLite.cs
+++ b/Example/Assets/Scripts/SQLite.cs
@@ -2659,6 +2659,15 @@ namespace SQLite4Unity3d
 					CommandText = valr.CommandText,
 					Value = valr.Value != null ? ConvertTo (valr.Value, ty) : null
 				};
+			} else if (expr.NodeType == ExpressionType.Not) {
+				var u = (UnaryExpression)expr;
+				var ty = u.Type;
+				var valr = CompileExpr (u.Operand, queryArgs);
+
+				return new CompileResult {
+					CommandText = "NOT " + valr.CommandText,
+					Value = valr.Value != null ? valr.Value : null
+				};
 			} else if (expr.NodeType == ExpressionType.MemberAccess) {
 				var mem = (MemberExpression)expr;
 				


### PR DESCRIPTION
Hi, 

Thank you very much for your plugin, it's great!

I was in the need to do a a SQL query using `NOT` operator in the `WHERE` (ie . `SELECT * FROM Table WHERE Field NOT LIKE "WHATEVER"`) clause and found out that it wasn't supported, so I've amended the code to get it working. Hopefully it can be useful for someone else in my situation.

Kind regards,
Javier