### PR TITLE
Added support for MacOSX Standalone

### DIFF
--- a/Example/Assets/Scripts/DataService.cs
+++ b/Example/Assets/Scripts/DataService.cs
@@ -42,6 +42,11 @@ public class DataService  {
 		var loadDb = Application.dataPath + "/StreamingAssets/" + DatabaseName;  // this is the path to your StreamingAssets in iOS
 		// then save to Application.persistentDataPath
 		File.Copy(loadDb, filepath);
+		
+#elif UNITY_STANDALONE_OSX
+		var loadDb = Application.dataPath + "/Resources/Data/StreamingAssets/" + DatabaseName;  // this is the path to your StreamingAssets in iOS
+		// then save to Application.persistentDataPath
+		File.Copy(loadDb, filepath);
 #else
 	var loadDb = Application.dataPath + "/StreamingAssets/" + DatabaseName;  // this is the path to your StreamingAssets in iOS
 	// then save to Application.persistentDataPath


### PR DESCRIPTION
Added database path handle for Mac OSX Standalone.
Path is : Application.dataPath + "/Resources/Data/StreamingAssets/" + DatabaseName;